### PR TITLE
fix the color matching pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = function(str) {
 
 	var m;
 
-	while (m = str.match(/\{([^\{\}]*)\}/)) {
+	while (m = str.match(/\{((?:#|>|rgb\()[^\{\}]*)\}/)) {
 
 		var prevcolor = color;
 		var prevbgcolor = bgcolor;


### PR DESCRIPTION
This change limits the possible matches to `{#color}`, `{rgb(color)}` and `{>...}`. The motivation behind this is the possibility to colorize JSON and `util.inspect()` dumps.